### PR TITLE
Applied fix from @https123456789 in issue #4.

### DIFF
--- a/Scripts/gitStats.js
+++ b/Scripts/gitStats.js
@@ -2,31 +2,29 @@ function getContribsFor(username, callback) {
 	var ret = {
 
 	}
-	var branches = {
-		"count": 0,
-		"shas": [
-
-		]
-	}
 	checkIfGAPICallsExist(function(useCached) {
 		console.log(useCached);
 		if (useCached) {
 			var req = new XMLHttpRequest();
 			req.addEventListener("load", function() {
 				if (this.status == 200) {
-					var authorCount = 0;
-					var json = JSON.parse(this.responseText);
-					for (var i = 0; i < json.length; i++) {
-						if (json[i]["author"]["login"] == username) {
-							authorCount += 1;
+					var res = JSON.parse(this.responseText);
+					var numberOfCommiters = res.length;
+					var totalCommits = 0;
+					console.log(numberOfCommiters);
+					for (var i = 0; i < numberOfCommiters; i++) {
+						if (res[i].author.login == username) {
+							ret.count = res[i].total;
 						}
+						totalCommits += res[i].total;
 					}
-					ret.count = authorCount;
-					ret.percent = Math.round((ret.count / json.length) * 100) / 100;
+					var percent = Math.round((ret.count / totalCommits) * 1000) / 1000;
+					console.log(res.percent);
+					ret.percent = percent;
 					callback(ret);
 				}
 			});
-			req.open("GET", "https://api.github.com/repos/https123456789/Textual/commits?type=all");
+			req.open("GET", "https://api.github.com/repos/https123456789/Textual/stats/contributors");
 			req.send();
 		} else {
 			// Use Cached API Data


### PR DESCRIPTION
Applied fix from @https123456789 in issue #4. Contributor stats are now accurate with the [main](<https://gituhb.com/https123456789/Textual/tree/main>) branch. This fix was based upon the idea from @https123456789 
 in [this](<https://github.com/https123456789/Textual/issues/4#issuecomment-955270171>) comment where he suggested this:
> The request queries for data about all commits but it seems that this doesn't work properly. The [docs](<https://docs.github.com/en/rest/reference/repos#get-all-contributor-commit-activity>) claim that a request can be made to `https://api.github.com/repos/{username}/{repo name}/stats/contributors` to find information about all of the repository contributors.

> The idea is to replace the existing request with this and rewrite the returned data processing which should create a more accurate representation of the number of commits a contributor has made to [Textual](<https://github.com/https123456789/Textual>).